### PR TITLE
builtin/string: correct documentation mistake 

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1312,7 +1312,7 @@ pub fn (s string) last_index_u8(c u8) int {
 }
 
 // count returns the number of occurrences of `substr` in the string.
-// count returns -1 if no `substr` could be found.
+// count returns 0 if no `substr` could be found.
 [direct_array_access]
 pub fn (s string) count(substr string) int {
 	if s.len == 0 || substr.len == 0 {


### PR DESCRIPTION
`string.count(substr)` returns 0 (not -1) when substr isn't found:

```
$ v repl
>>> "".count("z")
0
>>> exit
```

Given that in its [source code](https://github.com/vlang/v/blob/master/vlib/builtin/string.v#L1317), the returned value `n` is initialized to 0 and then only changed when incremented with `n++`, it cannot be negative.